### PR TITLE
use copy func to fixed nil pointer exception when Default.SecurityPar…

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -318,8 +318,7 @@ func (x *GoSNMP) validateParameters() error {
 func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint8, maxRepetitions uint8) *SnmpPacket {
 	var newSecParams SnmpV3SecurityParameters
 	if x.SecurityParameters != nil {
-		newSecParams = Default.SecurityParameters
-		newSecParams.setSecurityParameters(x.SecurityParameters)
+		newSecParams = x.SecurityParameters.Copy()
 	}
 	return &SnmpPacket{
 		Version:            x.Version,


### PR DESCRIPTION
…ameters and calling setSecurityParameters